### PR TITLE
Fixes #20 and removes depricated jobfiles

### DIFF
--- a/lib/lazythumb.php
+++ b/lib/lazythumb.php
@@ -140,10 +140,12 @@ class LazyThumb extends Thumb {
         $image = site()->image($thumbinfo['source']['filename']);
       } else {
         // Image belongs to a specific page
-        $image = page($thumbinfo['source']['page'])->image($thumbinfo['source']['filename']);
+        if ($page = page($thumbinfo['source']['page'])) {
+          $image = page($thumbinfo['source']['page'])->image($thumbinfo['source']['filename']);
+        }
       }
       
-      if(!$image) {
+      if (empty($image)) {
         // If source image does not exist any more, remove
         // the jobfile.
         f::remove($jobfile);


### PR DESCRIPTION
Jobfiles couldn't be executed when the images page has been renamed/moved. This commit adds a check, if the page still exists. Otherwise the jobfiles will be deleted without aborting the panel widget process.

I'm not sure if I tested all possible situations where the error may occure, but the fix works for me (so far).